### PR TITLE
Use the latest Tab Dev AMI (#258)

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -21,7 +21,7 @@ data "aws_ami" "tableau_nineteen" {
     name = "name"
 
     values = [
-      "dq-ops-win-tab-dev-248*",
+      "dq-ops-win-tab-dev-258*",
     ]
   }
 

--- a/instances.tf
+++ b/instances.tf
@@ -20,7 +20,7 @@ resource "aws_instance" "tableau" {
   }
 
   tags = {
-    Name = "ec2-deployment-${local.naming_suffix}-${count.index}"
+    Name = "tab-dep-${count.index + 1}-${local.naming_suffix}"
   }
 }
 
@@ -45,7 +45,7 @@ resource "aws_instance" "tableau_nineteen" {
   #}
 
   tags = {
-    Name = "ec2-deployment-nineteen-${local.naming_suffix}"
+    Name = "tab-dep-nineteen-${local.naming_suffix}"
   }
 }
 

--- a/tests/ops_test.py
+++ b/tests/ops_test.py
@@ -58,7 +58,7 @@ class TestE2E(unittest.TestCase):
         self.assertEqual(self.runner.get_value("module.tableau.aws_subnet.tableau_subnet", "tags"), {'Name': "subnet-tableau-ops-preprod-dq"})
 
     def test_name_tableau2(self):
-        self.assertEqual(self.runner.get_value("module.tableau.aws_instance.tableau[0]", "tags"), {'Name': "ec2-deployment-tableau-ops-preprod-dq-0"})
+        self.assertEqual(self.runner.get_value("module.tableau.aws_instance.tableau[0]", "tags"), {'Name': "tab-dep-1-tableau-ops-preprod-dq"})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 - Which is based on Win Bastion AMI #288
   - Which will copy the region & locale script to the host
 - Also rename the EC2 instances